### PR TITLE
Store attestation ID and redirect after profile completion

### DIFF
--- a/web3-app/src/app/api/profile/route.ts
+++ b/web3-app/src/app/api/profile/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+
+type ProfileRecord = { cid: string; attestationId: string };
+
+const profiles = new Map<string, ProfileRecord>();
+
+export async function POST(req: NextRequest) {
+  const { userId, cid, attestationId } = await req.json();
+  if (!userId || !cid || !attestationId) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+  profiles.set(userId, { cid, attestationId });
+  return NextResponse.json({ success: true });
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get("userId");
+  if (!userId || !profiles.has(userId)) {
+    return NextResponse.json({ found: false });
+  }
+  return NextResponse.json({ found: true, profile: profiles.get(userId) });
+}

--- a/web3-app/src/app/onboarding/page.tsx
+++ b/web3-app/src/app/onboarding/page.tsx
@@ -13,13 +13,20 @@ export default function OnboardingPage() {
 
   useEffect(() => {
     if (!privyConfigured) return;
-      if (ready && authenticated) {
-        if (!user?.profile) {
+    if (ready && authenticated && user) {
+      (async () => {
+        try {
+          const res = await fetch(`/api/profile?userId=${user.id}`);
+          const data = await res.json();
+          if (!data.found) {
+            router.replace("/profile/new");
+          }
+        } catch {
           router.replace("/profile/new");
         }
-        // stay on this page briefly so user can see status, then redirect on back/home
-      }
-    }, [ready, authenticated, privyConfigured, user, router]);
+      })();
+    }
+  }, [ready, authenticated, privyConfigured, user, router]);
 
   return (
     <main className="relative min-h-screen overflow-hidden vignette noise-soft aurora-bg">

--- a/web3-app/src/app/page.tsx
+++ b/web3-app/src/app/page.tsx
@@ -1,7 +1,12 @@
 import ConstellationCanvas from "@/components/ConstellationCanvas";
 import ConnectPanel from "@/components/ConnectPanel";
 
-export default function Home() {
+export default function Home({
+  searchParams,
+}: {
+  searchParams: { profile?: string };
+}) {
+  const profileCreated = searchParams.profile === "complete";
   return (
     <main className="relative min-h-screen overflow-hidden vignette noise-soft aurora-bg">
       <section className="relative mx-auto max-w-6xl px-6 py-24 sm:py-32">
@@ -29,6 +34,11 @@ export default function Home() {
           <div className="microcopy mt-2">
             No seed phrases. No gas. Yours to own.
           </div>
+          {profileCreated && (
+            <div className="mt-6 rounded-xl bg-green-500/20 text-green-400 p-4">
+              Profile saved successfully!
+            </div>
+          )}
           <div className="mt-6 rounded-xl bg-surface/40 backdrop-blur-xl p-4 pr-5 accent-ring inline-block">
             <ConnectPanel />
           </div>


### PR DESCRIPTION
## Summary
- add in-memory profile API to persist attestation pointers
- redirect after profile creation and mark profile complete
- surface success message on home screen and check profile in onboarding

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7461f1fc883259ef8c92c4e28e96e