### PR TITLE
feat: add identity registry with account abstraction

### DIFF
--- a/contracts/src/IdentityRegistry.sol
+++ b/contracts/src/IdentityRegistry.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+interface IEntryPoint {
+    // Intentionally left blank. Minimal interface for EntryPoint contract.
+}
+
+contract IdentityRegistry {
+    struct Identity {
+        bytes32 passkeyHash;
+        bytes32 emailHash;
+        string metadata;
+        bool revoked;
+        bool exists;
+    }
+
+    IEntryPoint public immutable entryPoint;
+
+    mapping(address => Identity) private identities;
+
+    event Registered(address indexed user, bytes32 passkeyHash, bytes32 emailHash, string metadata);
+    event MetadataUpdated(address indexed user, bytes32 passkeyHash, bytes32 emailHash, string metadata);
+    event Revoked(address indexed user);
+
+    modifier onlyEntryPoint() {
+        require(msg.sender == address(entryPoint), "Not EntryPoint");
+        _;
+    }
+
+    modifier onlyExisting(address user) {
+        require(identities[user].exists, "Not registered");
+        _;
+    }
+
+    modifier notRevoked(address user) {
+        require(!identities[user].revoked, "Account revoked");
+        _;
+    }
+
+    constructor(IEntryPoint _entryPoint) {
+        entryPoint = _entryPoint;
+    }
+
+    function register(
+        address user,
+        bytes32 passkeyHash,
+        bytes32 emailHash,
+        string calldata metadata
+    ) external onlyEntryPoint {
+        require(!identities[user].exists, "Already registered");
+        identities[user] = Identity(passkeyHash, emailHash, metadata, false, true);
+        emit Registered(user, passkeyHash, emailHash, metadata);
+    }
+
+    function updateMetadata(
+        address user,
+        bytes32 passkeyHash,
+        bytes32 emailHash,
+        string calldata metadata
+    ) external onlyEntryPoint onlyExisting(user) notRevoked(user) {
+        Identity storage id = identities[user];
+        id.passkeyHash = passkeyHash;
+        id.emailHash = emailHash;
+        id.metadata = metadata;
+        emit MetadataUpdated(user, passkeyHash, emailHash, metadata);
+    }
+
+    function revoke(address user) external onlyEntryPoint onlyExisting(user) notRevoked(user) {
+        identities[user].revoked = true;
+        emit Revoked(user);
+    }
+
+    function getIdentity(address user) external view returns (Identity memory) {
+        return identities[user];
+    }
+}
+

--- a/contracts/test/IdentityRegistry.t.sol
+++ b/contracts/test/IdentityRegistry.t.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "../src/IdentityRegistry.sol";
+
+contract MockEntryPoint {
+    function register(
+        IdentityRegistry registry,
+        address user,
+        bytes32 passkeyHash,
+        bytes32 emailHash,
+        string calldata metadata
+    ) external {
+        registry.register(user, passkeyHash, emailHash, metadata);
+    }
+
+    function updateMetadata(
+        IdentityRegistry registry,
+        address user,
+        bytes32 passkeyHash,
+        bytes32 emailHash,
+        string calldata metadata
+    ) external {
+        registry.updateMetadata(user, passkeyHash, emailHash, metadata);
+    }
+
+    function revoke(IdentityRegistry registry, address user) external {
+        registry.revoke(user);
+    }
+}
+
+contract IdentityRegistryTest {
+    IdentityRegistry private registry;
+    MockEntryPoint private entryPoint;
+    address private user = address(0x1);
+    bytes32 private passkey = keccak256(abi.encodePacked("pass"));
+    bytes32 private email = keccak256(abi.encodePacked("email"));
+    string private metadata = "meta";
+
+    function setupRegistry() internal {
+        entryPoint = new MockEntryPoint();
+        registry = new IdentityRegistry(IEntryPoint(address(entryPoint)));
+    }
+
+    function testRegister() public {
+        setupRegistry();
+        entryPoint.register(registry, user, passkey, email, metadata);
+        IdentityRegistry.Identity memory id = registry.getIdentity(user);
+        require(id.exists, "not registered");
+        require(id.passkeyHash == passkey, "passkey mismatch");
+        require(id.emailHash == email, "email mismatch");
+        require(keccak256(bytes(id.metadata)) == keccak256(bytes(metadata)), "metadata mismatch");
+        require(!id.revoked, "revoked");
+    }
+
+    function testUpdateMetadata() public {
+        setupRegistry();
+        entryPoint.register(registry, user, passkey, email, metadata);
+        bytes32 newPass = keccak256(abi.encodePacked("newpass"));
+        bytes32 newEmail = keccak256(abi.encodePacked("newemail"));
+        string memory newMetadata = "new";
+        entryPoint.updateMetadata(registry, user, newPass, newEmail, newMetadata);
+        IdentityRegistry.Identity memory id = registry.getIdentity(user);
+        require(id.passkeyHash == newPass, "passkey mismatch");
+        require(id.emailHash == newEmail, "email mismatch");
+        require(keccak256(bytes(id.metadata)) == keccak256(bytes(newMetadata)), "metadata mismatch");
+    }
+
+    function testRevoke() public {
+        setupRegistry();
+        entryPoint.register(registry, user, passkey, email, metadata);
+        entryPoint.revoke(registry, user);
+        IdentityRegistry.Identity memory id = registry.getIdentity(user);
+        require(id.revoked, "not revoked");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add IdentityRegistry contract with ERC-4337 EntryPoint gating
- enable registration, metadata updates, and account revocation
- include tests covering registry flows

## Testing
- `forge test -q` *(fails: command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7493598088325979833ea089c8737