### PR TITLE
feat: add profile manager with EAS attestations

### DIFF
--- a/contracts/src/ProfileManager.sol
+++ b/contracts/src/ProfileManager.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+interface IEAS {
+    function attest(bytes32 schema, address recipient, bytes calldata data) external returns (bytes32);
+}
+
+contract ProfileManager {
+    IEAS public immutable eas;
+    bytes32 public immutable schema;
+    address public owner;
+
+    mapping(address => bool) public moderators;
+    mapping(address => string) public profiles;
+
+    event ProfileUpdated(address indexed user, string cid, bytes32 attestationUID);
+    event ModeratorUpdated(address indexed moderator, bool enabled);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    modifier onlyAuthorized(address user) {
+        require(msg.sender == user || moderators[msg.sender], "Not authorized");
+        _;
+    }
+
+    constructor(IEAS _eas, bytes32 _schema) {
+        eas = _eas;
+        schema = _schema;
+        owner = msg.sender;
+    }
+
+    function setModerator(address moderator, bool enabled) external onlyOwner {
+        moderators[moderator] = enabled;
+        emit ModeratorUpdated(moderator, enabled);
+    }
+
+    function setProfile(string calldata cid) external returns (bytes32) {
+        return _setProfile(msg.sender, cid);
+    }
+
+    function setProfileFor(address user, string calldata cid) external onlyAuthorized(user) returns (bytes32) {
+        return _setProfile(user, cid);
+    }
+
+    function _setProfile(address user, string calldata cid) internal returns (bytes32 uid) {
+        profiles[user] = cid;
+        uid = eas.attest(schema, user, bytes(cid));
+        emit ProfileUpdated(user, cid, uid);
+    }
+
+    function getProfile(address user) external view returns (string memory) {
+        return profiles[user];
+    }
+}
+

--- a/contracts/test/ProfileManager.t.sol
+++ b/contracts/test/ProfileManager.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "../src/ProfileManager.sol";
+
+contract MockEAS {
+    bytes32 public lastSchema;
+    address public lastRecipient;
+    bytes public lastData;
+    bytes32 public lastUID;
+
+    function attest(bytes32 schema, address recipient, bytes calldata data) external returns (bytes32) {
+        lastSchema = schema;
+        lastRecipient = recipient;
+        lastData = data;
+        lastUID = bytes32(uint256(lastUID) + 1);
+        return lastUID;
+    }
+}
+
+contract User {
+    function set(ProfileManager manager, string calldata cid) external returns (bytes32) {
+        return manager.setProfile(cid);
+    }
+
+    function setFor(ProfileManager manager, address user, string calldata cid) external returns (bytes32) {
+        return manager.setProfileFor(user, cid);
+    }
+}
+
+contract ProfileManagerTest {
+    MockEAS private eas;
+    ProfileManager private manager;
+    User private user;
+    User private mod;
+    bytes32 private schema = keccak256("profile");
+
+    function setup() internal {
+        eas = new MockEAS();
+        manager = new ProfileManager(IEAS(address(eas)), schema);
+        user = new User();
+        mod = new User();
+        manager.setModerator(address(mod), true);
+    }
+
+    function testProfileCreation() public {
+        setup();
+        bytes32 uid = user.set(manager, "cid1");
+        string memory stored = manager.getProfile(address(user));
+        require(keccak256(bytes(stored)) == keccak256(bytes("cid1")), "cid");
+        require(eas.lastRecipient() == address(user), "recipient");
+        require(keccak256(eas.lastData()) == keccak256(bytes("cid1")), "data");
+        require(uid == eas.lastUID(), "uid");
+    }
+
+    function testProfileUpdateByModerator() public {
+        setup();
+        user.set(manager, "cid1");
+        bytes32 uid = mod.setFor(manager, address(user), "cid2");
+        string memory stored = manager.getProfile(address(user));
+        require(keccak256(bytes(stored)) == keccak256(bytes("cid2")), "cid");
+        require(eas.lastRecipient() == address(user), "recipient");
+        require(keccak256(eas.lastData()) == keccak256(bytes("cid2")), "data");
+        require(uid == eas.lastUID(), "uid");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ProfileManager contract for IPFS-based profile pointers
- support EAS attestations when profiles are set or updated
- test profile creation and moderator updates with attestation linkage

## Testing
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b749f8cf208325a363d5afb8e1819a