### PR TITLE
Add match scoring engine with configurable weights

### DIFF
--- a/contracts/src/MatchEngine.sol
+++ b/contracts/src/MatchEngine.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+interface IProfileManager {
+    function getProfile(address user) external view returns (string memory);
+}
+
+contract MatchEngine {
+    struct Weights {
+        uint256 profileWeight;
+        uint256 addressWeight;
+    }
+
+    IProfileManager public immutable profiles;
+    address public admin;
+    Weights public weights;
+
+    mapping(address => mapping(address => bool)) public blocked;
+
+    event WeightsUpdated(uint256 profileWeight, uint256 addressWeight);
+    event AdminUpdated(address indexed newAdmin);
+    event BlockStatus(address indexed user, address indexed target, bool blocked);
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "Not admin");
+        _;
+    }
+
+    constructor(IProfileManager _profiles, Weights memory initialWeights) {
+        profiles = _profiles;
+        admin = msg.sender;
+        weights = initialWeights;
+    }
+
+    function setAdmin(address newAdmin) external onlyAdmin {
+        admin = newAdmin;
+        emit AdminUpdated(newAdmin);
+    }
+
+    function updateWeights(Weights calldata newWeights) external onlyAdmin {
+        weights = newWeights;
+        emit WeightsUpdated(newWeights.profileWeight, newWeights.addressWeight);
+    }
+
+    function setBlock(address target, bool isBlocked) external {
+        blocked[msg.sender][target] = isBlocked;
+        emit BlockStatus(msg.sender, target, isBlocked);
+    }
+
+    function score(address userA, address userB) external view returns (uint256) {
+        if (userA == userB) return 0;
+        if (blocked[userA][userB] || blocked[userB][userA]) return 0;
+
+        string memory profileA = profiles.getProfile(userA);
+        string memory profileB = profiles.getProfile(userB);
+
+        (address a1, address a2) = userA < userB ? (userA, userB) : (userB, userA);
+        (string memory p1, string memory p2) = userA < userB
+            ? (profileA, profileB)
+            : (profileB, profileA);
+
+        uint256 profileHash = uint256(keccak256(abi.encodePacked(p1, p2)));
+        uint256 addressHash = uint256(keccak256(abi.encodePacked(a1, a2)));
+
+        return profileHash * weights.profileWeight + addressHash * weights.addressWeight;
+    }
+}
+

--- a/contracts/test/MatchEngine.t.sol
+++ b/contracts/test/MatchEngine.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "../src/MatchEngine.sol";
+
+contract MockProfileManager is IProfileManager {
+    mapping(address => string) public profiles;
+
+    function set(address user, string memory cid) external {
+        profiles[user] = cid;
+    }
+
+    function getProfile(address user) external view returns (string memory) {
+        return profiles[user];
+    }
+}
+
+contract User {
+    function blockAddr(MatchEngine engine, address target, bool isBlocked) external {
+        engine.setBlock(target, isBlocked);
+    }
+}
+
+contract MatchEngineTest {
+    MockProfileManager private pm;
+    MatchEngine private engine;
+    User private ua;
+    User private ub;
+
+    function setup() internal {
+        pm = new MockProfileManager();
+        ua = new User();
+        ub = new User();
+        pm.set(address(ua), "A");
+        pm.set(address(ub), "B");
+        MatchEngine.Weights memory w = MatchEngine.Weights({profileWeight: 1, addressWeight: 1});
+        engine = new MatchEngine(IProfileManager(address(pm)), w);
+    }
+
+    function expectedScore(address a, address b) internal view returns (uint256) {
+        string memory pa = pm.getProfile(a);
+        string memory pb = pm.getProfile(b);
+        (address a1, address a2) = a < b ? (a, b) : (b, a);
+        (string memory p1, string memory p2) = a < b ? (pa, pb) : (pb, pa);
+        uint256 profileHash = uint256(keccak256(abi.encodePacked(p1, p2)));
+        uint256 addressHash = uint256(keccak256(abi.encodePacked(a1, a2)));
+        return profileHash + addressHash;
+    }
+
+    function testScoreDeterministic() public {
+        setup();
+        uint256 expected = expectedScore(address(ua), address(ub));
+        uint256 result = engine.score(address(ua), address(ub));
+        require(result == expected, "score");
+    }
+
+    function testSelfMatch() public {
+        setup();
+        uint256 result = engine.score(address(ua), address(ua));
+        require(result == 0, "self");
+    }
+
+    function testBlockedMatch() public {
+        setup();
+        ua.blockAddr(engine, address(ub), true);
+        uint256 result = engine.score(address(ua), address(ub));
+        require(result == 0, "blocked");
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement MatchEngine for deterministic user scoring with profile-based weights
- allow admin governance to adjust weights and manage blocklist
- add tests for deterministic scoring, self-matching, and blocked users

## Testing
- `forge test` *(fails: command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b74ab90a408325be7bbd73a6c6dfd1