### PR TITLE
Add incentive mechanism with deposit staking and slashing

### DIFF
--- a/contracts/src/IncentiveMechanism.sol
+++ b/contracts/src/IncentiveMechanism.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+contract IncentiveMechanism {
+    uint256 public immutable depositAmount;
+    uint256 public immutable cooldown;
+    address public immutable treasury;
+
+    mapping(address => uint256) public lastContact;
+    mapping(bytes32 => uint256) public deposits;
+
+    event ContactInitiated(address indexed initiator, address indexed target, uint256 amount);
+    event ContactRefunded(address indexed initiator, address indexed target, uint256 amount);
+    event ContactSlashed(address indexed initiator, address indexed target, uint256 amount);
+
+    constructor(uint256 _depositAmount, uint256 _cooldown, address _treasury) {
+        depositAmount = _depositAmount;
+        cooldown = _cooldown;
+        treasury = _treasury;
+    }
+
+    function _key(address initiator, address target) private pure returns (bytes32) {
+        return keccak256(abi.encode(initiator, target));
+    }
+
+    function initiateContact(address target) external payable {
+        require(msg.value == depositAmount, "wrong deposit");
+        require(block.timestamp >= lastContact[msg.sender] + cooldown, "rate limited");
+        bytes32 key = _key(msg.sender, target);
+        require(deposits[key] == 0, "active deposit");
+        deposits[key] = msg.value;
+        lastContact[msg.sender] = block.timestamp;
+        emit ContactInitiated(msg.sender, target, msg.value);
+    }
+
+    function refund(address initiator) external {
+        bytes32 key = _key(initiator, msg.sender);
+        uint256 amount = deposits[key];
+        require(amount > 0, "no deposit");
+        deposits[key] = 0;
+        (bool ok, ) = initiator.call{value: amount}("");
+        require(ok, "refund failed");
+        emit ContactRefunded(initiator, msg.sender, amount);
+    }
+
+    function slash(address initiator) external {
+        bytes32 key = _key(initiator, msg.sender);
+        uint256 amount = deposits[key];
+        require(amount > 0, "no deposit");
+        deposits[key] = 0;
+        (bool ok, ) = treasury.call{value: amount}("");
+        require(ok, "slash failed");
+        emit ContactSlashed(initiator, msg.sender, amount);
+    }
+}

--- a/contracts/test/IncentiveMechanism.t.sol
+++ b/contracts/test/IncentiveMechanism.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "../src/IncentiveMechanism.sol";
+
+contract Target {
+    function refund(IncentiveMechanism m, address initiator) external {
+        m.refund(initiator);
+    }
+
+    function slash(IncentiveMechanism m, address initiator) external {
+        m.slash(initiator);
+    }
+}
+
+contract Treasury {
+    receive() external payable {}
+}
+
+contract IncentiveMechanismTest {
+    IncentiveMechanism private mech;
+    Target private target;
+    Treasury private treasury;
+
+    function setup() internal {
+        treasury = new Treasury();
+        mech = new IncentiveMechanism(1 ether, 1 hours, address(treasury));
+        target = new Target();
+    }
+
+    function testStakeAndRateLimit() public {
+        setup();
+        mech.initiateContact{value: 1 ether}(address(target));
+        require(address(mech).balance == 1 ether, "stake");
+        (bool ok, ) = address(mech).call{value: 1 ether}(abi.encodeWithSignature("initiateContact(address)", address(target)));
+        require(!ok, "rate limit");
+    }
+
+    function testRefund() public {
+        setup();
+        uint256 balBefore = address(this).balance;
+        mech.initiateContact{value: 1 ether}(address(target));
+        target.refund(mech, address(this));
+        require(address(this).balance == balBefore, "refund");
+    }
+
+    function testSlash() public {
+        setup();
+        mech.initiateContact{value: 1 ether}(address(target));
+        target.slash(mech, address(this));
+        require(address(treasury).balance == 1 ether, "slash");
+    }
+}


### PR DESCRIPTION
## Summary
- add IncentiveMechanism contract requiring deposits for contact initiation with cooldown-based rate limiting
- enable refunding or slashing deposits, routing penalties to a community treasury
- test staking, refund and slashing flows including rate limit enforcement

## Testing
- `forge test` *(fails: command not found; Foundry not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68b74b71236483259088b8fac5b05686