### PR TITLE
feat: add safety report system

### DIFF
--- a/contracts/src/SafetyReport.sol
+++ b/contracts/src/SafetyReport.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+interface IEAS {
+    function attest(bytes32 schema, address recipient, bytes calldata data) external returns (bytes32);
+}
+
+contract SafetyReport {
+    IEAS public immutable eas;
+    bytes32 public immutable schema;
+
+    struct Report {
+        address reporter;
+        address subject;
+        string evidence;
+        int256 scoreChange;
+        bytes32 uid;
+    }
+
+    mapping(address => int256) public reputation;
+    Report[] private reports;
+
+    event ReportSubmitted(address indexed reporter, address indexed subject, string evidence, int256 scoreChange, bytes32 attestationUID);
+
+    constructor(IEAS _eas, bytes32 _schema) {
+        eas = _eas;
+        schema = _schema;
+    }
+
+    function submitReport(address subject, string calldata encryptedEvidence, int256 scoreChange) external returns (bytes32 uid) {
+        uid = eas.attest(schema, subject, abi.encode(encryptedEvidence, scoreChange));
+        reputation[subject] += scoreChange;
+        reports.push(Report(msg.sender, subject, encryptedEvidence, scoreChange, uid));
+        emit ReportSubmitted(msg.sender, subject, encryptedEvidence, scoreChange, uid);
+    }
+
+    function getReputation(address account) external view returns (int256) {
+        return reputation[account];
+    }
+
+    function getReport(uint256 index) external view returns (Report memory) {
+        return reports[index];
+    }
+
+    function totalReports() external view returns (uint256) {
+        return reports.length;
+    }
+}
+

--- a/contracts/test/SafetyReport.t.sol
+++ b/contracts/test/SafetyReport.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "../src/SafetyReport.sol";
+
+contract MockEAS {
+    bytes32 public lastSchema;
+    address public lastRecipient;
+    bytes public lastData;
+    bytes32 public lastUID;
+
+    function attest(bytes32 schema, address recipient, bytes calldata data) external returns (bytes32) {
+        lastSchema = schema;
+        lastRecipient = recipient;
+        lastData = data;
+        lastUID = bytes32(uint256(lastUID) + 1);
+        return lastUID;
+    }
+}
+
+contract SafetyReportTest {
+    MockEAS private eas;
+    SafetyReport private reports;
+    bytes32 private schema = keccak256("report");
+
+    function setup() internal {
+        eas = new MockEAS();
+        reports = new SafetyReport(IEAS(address(eas)), schema);
+    }
+
+    function testSubmitReport() public {
+        setup();
+        address user = address(0xBEEF);
+        bytes32 uid = reports.submitReport(user, "encryptedCID", 1);
+        int256 rep = reports.getReputation(user);
+        require(rep == 1, "reputation");
+        require(eas.lastRecipient() == user, "recipient");
+        (string memory cid, int256 change) = abi.decode(eas.lastData(), (string, int256));
+        require(keccak256(bytes(cid)) == keccak256(bytes("encryptedCID")), "cid");
+        require(change == 1, "change");
+        require(uid == eas.lastUID(), "uid");
+    }
+
+    function testMultipleReportsAdjustReputation() public {
+        setup();
+        address user = address(0xBEEF);
+        reports.submitReport(user, "cid1", 2);
+        reports.submitReport(user, "cid2", -1);
+        int256 rep = reports.getReputation(user);
+        require(rep == 1, "sum");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add SafetyReport contract for encrypted evidence and EAS attestations
- track reputation per account with read APIs
- add tests for report submission and reputation updates

## Testing
- `forge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74c3884f8832587854e77ef0a8c19