### PR TITLE
feat: add smart account onboarding

### DIFF
--- a/web3-app/README.md
+++ b/web3-app/README.md
@@ -6,6 +6,8 @@ Env setup:
 
 ```
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id_here
+NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id
+NEXT_PUBLIC_ZERODEV_PROJECT_ID=your_zerodev_project_id
 ```
 
 Run the development server:

--- a/web3-app/src/app/onboarding/page.tsx
+++ b/web3-app/src/app/onboarding/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect } from "react";
-import { usePrivy } from "@privy-io/react-auth";
+import { usePrivy, type Wallet } from "@privy-io/react-auth";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import SmartAccountStatus from "@/components/SmartAccountStatus";
+import { ensureSmartAccount } from "@/lib/aa";
 
 export default function OnboardingPage() {
   const { login, ready, authenticated, user } = usePrivy();
@@ -15,6 +16,11 @@ export default function OnboardingPage() {
     if (!privyConfigured) return;
     if (ready && authenticated && user) {
       (async () => {
+        const wallets = (user.linkedAccounts ?? []).filter(
+          (a): a is Wallet => a.type === "wallet"
+        );
+        const info = await ensureSmartAccount(wallets);
+        if (!info.isReady) return;
         try {
           const res = await fetch(`/api/profile?userId=${user.id}`);
           const data = await res.json();


### PR DESCRIPTION
## Summary
- create ZeroDev paymaster-backed ERC-4337 client for gasless smart accounts
- trigger smart-account creation after passkey/email login during onboarding
- document required Privy and ZeroDev env vars

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b9f9f9a8b883259be66b9ad789f19b