### PR TITLE
feat: add profile data layer with attestations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Kindling addresses these issues with a protocol-first design: an open-source, au
 - IPFS/Arweave pointers for encrypted profile blobs.
 - Attestations for preferences, verification, and safety signals.
 
+The `ProfileManager` contract now stores a public handle and an IPFS CID pointing to an encrypted profile blob. Users and approved moderators can update profiles while emitting an EAS attestation. Additional helper methods issue attestations for user preferences, verification checks, and safety signals, enabling portable reputation across the protocol.
+
 ### Match Engine
 
 - Open, transparent scoring function.

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -14,7 +14,10 @@ import {SafetyReport, IEAS as IEASSafetyReport} from "../src/SafetyReport.sol";
 ///
 ///         - ENTRY_POINT: address of the ERC-4337 EntryPoint contract
 ///         - EAS: address of the Ethereum Attestation Service contract
-///         - PROFILE_SCHEMA: bytes32 schema used by ProfileManager
+///         - PROFILE_SCHEMA: bytes32 schema for profile data
+///         - PREF_SCHEMA: bytes32 schema for user preferences
+///         - VERIFY_SCHEMA: bytes32 schema for verification signals
+///         - SAFETY_SCHEMA: bytes32 schema for safety signals
 ///         - REPORT_SCHEMA: bytes32 schema used by SafetyReport
 ///         - PROFILE_WEIGHT: uint weight for profile matching
 ///         - ADDRESS_WEIGHT: uint weight for address matching
@@ -27,6 +30,9 @@ contract Deploy is Script {
         IEntryPoint entryPoint = IEntryPoint(vm.envAddress("ENTRY_POINT"));
         IEAS eas = IEAS(vm.envAddress("EAS"));
         bytes32 profileSchema = vm.envBytes32("PROFILE_SCHEMA");
+        bytes32 prefSchema = vm.envBytes32("PREF_SCHEMA");
+        bytes32 verifySchema = vm.envBytes32("VERIFY_SCHEMA");
+        bytes32 safetySchema = vm.envBytes32("SAFETY_SCHEMA");
         bytes32 reportSchema = vm.envBytes32("REPORT_SCHEMA");
         uint256 profileWeight = vm.envUint("PROFILE_WEIGHT");
         uint256 addressWeight = vm.envUint("ADDRESS_WEIGHT");
@@ -39,7 +45,13 @@ contract Deploy is Script {
         IdentityRegistry registry = new IdentityRegistry(entryPoint);
         console2.log("IdentityRegistry", address(registry));
 
-        ProfileManager profileManager = new ProfileManager(eas, profileSchema);
+        ProfileManager profileManager = new ProfileManager(
+            eas,
+            profileSchema,
+            prefSchema,
+            verifySchema,
+            safetySchema
+        );
         console2.log("ProfileManager", address(profileManager));
 
         MatchEngine.Weights memory weights = MatchEngine.Weights({

--- a/contracts/src/MatchEngine.sol
+++ b/contracts/src/MatchEngine.sol
@@ -2,7 +2,11 @@
 pragma solidity ^0.8.26;
 
 interface IProfileManager {
-    function getProfile(address user) external view returns (string memory);
+    struct Profile {
+        string handle;
+        string cid;
+    }
+    function getProfile(address user) external view returns (Profile memory);
 }
 
 contract MatchEngine {
@@ -51,13 +55,13 @@ contract MatchEngine {
         if (userA == userB) return 0;
         if (blocked[userA][userB] || blocked[userB][userA]) return 0;
 
-        string memory profileA = profiles.getProfile(userA);
-        string memory profileB = profiles.getProfile(userB);
+        IProfileManager.Profile memory profileA = profiles.getProfile(userA);
+        IProfileManager.Profile memory profileB = profiles.getProfile(userB);
 
         (address a1, address a2) = userA < userB ? (userA, userB) : (userB, userA);
         (string memory p1, string memory p2) = userA < userB
-            ? (profileA, profileB)
-            : (profileB, profileA);
+            ? (profileA.cid, profileB.cid)
+            : (profileB.cid, profileA.cid);
 
         uint256 profileHash = uint256(keccak256(abi.encodePacked(p1, p2)));
         uint256 addressHash = uint256(keccak256(abi.encodePacked(a1, a2)));

--- a/contracts/src/ProfileManager.sol
+++ b/contracts/src/ProfileManager.sol
@@ -7,13 +7,25 @@ interface IEAS {
 
 contract ProfileManager {
     IEAS public immutable eas;
-    bytes32 public immutable schema;
+    bytes32 public immutable profileSchema;
+    bytes32 public immutable preferencesSchema;
+    bytes32 public immutable verificationSchema;
+    bytes32 public immutable safetySchema;
     address public owner;
 
     mapping(address => bool) public moderators;
-    mapping(address => string) public profiles;
 
-    event ProfileUpdated(address indexed user, string cid, bytes32 attestationUID);
+    struct Profile {
+        string handle; // minimal PII on-chain
+        string cid; // encrypted blob off-chain
+    }
+
+    mapping(address => Profile) private profiles;
+
+    event ProfileUpdated(address indexed user, string handle, string cid, bytes32 attestationUID);
+    event PreferencesAttested(address indexed user, bytes32 attestationUID);
+    event VerificationAttested(address indexed user, bytes32 attestationUID);
+    event SafetySignalAttested(address indexed user, bytes32 attestationUID);
     event ModeratorUpdated(address indexed moderator, bool enabled);
 
     modifier onlyOwner() {
@@ -26,9 +38,18 @@ contract ProfileManager {
         _;
     }
 
-    constructor(IEAS _eas, bytes32 _schema) {
+    constructor(
+        IEAS _eas,
+        bytes32 _profileSchema,
+        bytes32 _preferencesSchema,
+        bytes32 _verificationSchema,
+        bytes32 _safetySchema
+    ) {
         eas = _eas;
-        schema = _schema;
+        profileSchema = _profileSchema;
+        preferencesSchema = _preferencesSchema;
+        verificationSchema = _verificationSchema;
+        safetySchema = _safetySchema;
         owner = msg.sender;
     }
 
@@ -37,22 +58,45 @@ contract ProfileManager {
         emit ModeratorUpdated(moderator, enabled);
     }
 
-    function setProfile(string calldata cid) external returns (bytes32) {
-        return _setProfile(msg.sender, cid);
+    function setProfile(string calldata handle, string calldata cid) external returns (bytes32) {
+        return _setProfile(msg.sender, handle, cid);
     }
 
-    function setProfileFor(address user, string calldata cid) external onlyAuthorized(user) returns (bytes32) {
-        return _setProfile(user, cid);
+    function setProfileFor(address user, string calldata handle, string calldata cid)
+        external
+        onlyAuthorized(user)
+        returns (bytes32)
+    {
+        return _setProfile(user, handle, cid);
     }
 
-    function _setProfile(address user, string calldata cid) internal returns (bytes32 uid) {
-        profiles[user] = cid;
-        uid = eas.attest(schema, user, bytes(cid));
-        emit ProfileUpdated(user, cid, uid);
+    function _setProfile(address user, string calldata handle, string calldata cid) internal returns (bytes32 uid) {
+        profiles[user] = Profile({handle: handle, cid: cid});
+        uid = eas.attest(profileSchema, user, abi.encode(handle, cid));
+        emit ProfileUpdated(user, handle, cid, uid);
     }
 
-    function getProfile(address user) external view returns (string memory) {
+    function getProfile(address user) external view returns (Profile memory) {
         return profiles[user];
+    }
+
+    function attestPreferences(bytes calldata data) external returns (bytes32 uid) {
+        uid = eas.attest(preferencesSchema, msg.sender, data);
+        emit PreferencesAttested(msg.sender, uid);
+    }
+
+    function attestVerification(bytes calldata data) external returns (bytes32 uid) {
+        uid = eas.attest(verificationSchema, msg.sender, data);
+        emit VerificationAttested(msg.sender, uid);
+    }
+
+    function attestSafetySignal(address user, bytes calldata data)
+        external
+        onlyAuthorized(user)
+        returns (bytes32 uid)
+    {
+        uid = eas.attest(safetySchema, user, data);
+        emit SafetySignalAttested(user, uid);
     }
 }
 

--- a/contracts/test/MatchEngine.t.sol
+++ b/contracts/test/MatchEngine.t.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.26;
 import "../src/MatchEngine.sol";
 
 contract MockProfileManager is IProfileManager {
-    mapping(address => string) public profiles;
+    mapping(address => Profile) public profiles;
 
-    function set(address user, string memory cid) external {
-        profiles[user] = cid;
+    function set(address user, string memory handle, string memory cid) external {
+        profiles[user] = Profile({handle: handle, cid: cid});
     }
 
-    function getProfile(address user) external view returns (string memory) {
+    function getProfile(address user) external view returns (Profile memory) {
         return profiles[user];
     }
 }
@@ -31,15 +31,15 @@ contract MatchEngineTest {
         pm = new MockProfileManager();
         ua = new User();
         ub = new User();
-        pm.set(address(ua), "A");
-        pm.set(address(ub), "B");
+        pm.set(address(ua), "alice", "A");
+        pm.set(address(ub), "bob", "B");
         MatchEngine.Weights memory w = MatchEngine.Weights({profileWeight: 1, addressWeight: 1});
         engine = new MatchEngine(IProfileManager(address(pm)), w);
     }
 
     function expectedScore(address a, address b) internal view returns (uint256) {
-        string memory pa = pm.getProfile(a);
-        string memory pb = pm.getProfile(b);
+        string memory pa = pm.getProfile(a).cid;
+        string memory pb = pm.getProfile(b).cid;
         (address a1, address a2) = a < b ? (a, b) : (b, a);
         (string memory p1, string memory p2) = a < b ? (pa, pb) : (pb, pa);
         uint256 profileHash = uint256(keccak256(abi.encodePacked(p1, p2)));

--- a/contracts/test/ProfileManager.t.sol
+++ b/contracts/test/ProfileManager.t.sol
@@ -19,12 +19,29 @@ contract MockEAS {
 }
 
 contract User {
-    function set(ProfileManager manager, string calldata cid) external returns (bytes32) {
-        return manager.setProfile(cid);
+    function set(ProfileManager manager, string calldata handle, string calldata cid) external returns (bytes32) {
+        return manager.setProfile(handle, cid);
     }
 
-    function setFor(ProfileManager manager, address user, string calldata cid) external returns (bytes32) {
-        return manager.setProfileFor(user, cid);
+    function setFor(
+        ProfileManager manager,
+        address user,
+        string calldata handle,
+        string calldata cid
+    ) external returns (bytes32) {
+        return manager.setProfileFor(user, handle, cid);
+    }
+
+    function attestPrefs(ProfileManager manager, bytes calldata data) external returns (bytes32) {
+        return manager.attestPreferences(data);
+    }
+
+    function attestVerify(ProfileManager manager, bytes calldata data) external returns (bytes32) {
+        return manager.attestVerification(data);
+    }
+
+    function attestSafety(ProfileManager manager, address user, bytes calldata data) external returns (bytes32) {
+        return manager.attestSafetySignal(user, data);
     }
 }
 
@@ -33,11 +50,20 @@ contract ProfileManagerTest {
     ProfileManager private manager;
     User private user;
     User private mod;
-    bytes32 private schema = keccak256("profile");
+    bytes32 private profileSchema = keccak256("profile");
+    bytes32 private prefSchema = keccak256("prefs");
+    bytes32 private verifySchema = keccak256("verify");
+    bytes32 private safetySchema = keccak256("safety");
 
     function setup() internal {
         eas = new MockEAS();
-        manager = new ProfileManager(IEAS(address(eas)), schema);
+        manager = new ProfileManager(
+            IEAS(address(eas)),
+            profileSchema,
+            prefSchema,
+            verifySchema,
+            safetySchema
+        );
         user = new User();
         mod = new User();
         manager.setModerator(address(mod), true);
@@ -45,23 +71,48 @@ contract ProfileManagerTest {
 
     function testProfileCreation() public {
         setup();
-        bytes32 uid = user.set(manager, "cid1");
-        string memory stored = manager.getProfile(address(user));
-        require(keccak256(bytes(stored)) == keccak256(bytes("cid1")), "cid");
+        bytes32 uid = user.set(manager, "alice", "cid1");
+        ProfileManager.Profile memory stored = manager.getProfile(address(user));
+        require(keccak256(bytes(stored.handle)) == keccak256(bytes("alice")), "handle");
+        require(keccak256(bytes(stored.cid)) == keccak256(bytes("cid1")), "cid");
+        require(eas.lastSchema() == profileSchema, "schema");
         require(eas.lastRecipient() == address(user), "recipient");
-        require(keccak256(eas.lastData()) == keccak256(bytes("cid1")), "data");
+        require(keccak256(eas.lastData()) == keccak256(abi.encode("alice", "cid1")), "data");
         require(uid == eas.lastUID(), "uid");
     }
 
     function testProfileUpdateByModerator() public {
         setup();
-        user.set(manager, "cid1");
-        bytes32 uid = mod.setFor(manager, address(user), "cid2");
-        string memory stored = manager.getProfile(address(user));
-        require(keccak256(bytes(stored)) == keccak256(bytes("cid2")), "cid");
+        user.set(manager, "alice", "cid1");
+        bytes32 uid = mod.setFor(manager, address(user), "bob", "cid2");
+        ProfileManager.Profile memory stored = manager.getProfile(address(user));
+        require(keccak256(bytes(stored.handle)) == keccak256(bytes("bob")), "handle");
+        require(keccak256(bytes(stored.cid)) == keccak256(bytes("cid2")), "cid");
+        require(eas.lastSchema() == profileSchema, "schema");
         require(eas.lastRecipient() == address(user), "recipient");
-        require(keccak256(eas.lastData()) == keccak256(bytes("cid2")), "data");
+        require(keccak256(eas.lastData()) == keccak256(abi.encode("bob", "cid2")), "data");
         require(uid == eas.lastUID(), "uid");
+    }
+
+    function testAttestations() public {
+        setup();
+        bytes32 prefUid = user.attestPrefs(manager, bytes("dark"));
+        require(eas.lastSchema() == prefSchema, "pref schema");
+        require(eas.lastRecipient() == address(user), "pref recipient");
+        require(keccak256(eas.lastData()) == keccak256(bytes("dark")), "pref data");
+        require(prefUid == eas.lastUID(), "pref uid");
+
+        bytes32 verUid = user.attestVerify(manager, bytes("kyc"));
+        require(eas.lastSchema() == verifySchema, "verify schema");
+        require(eas.lastRecipient() == address(user), "verify recipient");
+        require(keccak256(eas.lastData()) == keccak256(bytes("kyc")), "verify data");
+        require(verUid == eas.lastUID(), "verify uid");
+
+        bytes32 safeUid = mod.attestSafety(manager, address(user), bytes("safe"));
+        require(eas.lastSchema() == safetySchema, "safety schema");
+        require(eas.lastRecipient() == address(user), "safety recipient");
+        require(keccak256(eas.lastData()) == keccak256(bytes("safe")), "safety data");
+        require(safeUid == eas.lastUID(), "safety uid");
     }
 }
 

--- a/web3-app/src/lib/profile.ts
+++ b/web3-app/src/lib/profile.ts
@@ -1,0 +1,44 @@
+import { uploadToIpfs } from './storage';
+
+// Basic profile fields before encryption
+export interface ProfileBlob {
+  handle: string;
+  bio?: string;
+  preferences?: string[];
+}
+
+/**
+ * Encrypt a profile object using AES-GCM.
+ * The resulting blob contains the IV followed by ciphertext.
+ */
+export async function encryptProfile(profile: ProfileBlob, key: CryptoKey): Promise<Blob> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(JSON.stringify(profile));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+  const result = new Uint8Array(iv.length + cipher.byteLength);
+  result.set(iv, 0);
+  result.set(new Uint8Array(cipher), iv.length);
+  return new Blob([result], { type: 'application/octet-stream' });
+}
+
+/**
+ * Decrypt a previously encrypted profile blob.
+ */
+export async function decryptProfile(blob: Blob, key: CryptoKey): Promise<ProfileBlob> {
+  const buf = new Uint8Array(await blob.arrayBuffer());
+  const iv = buf.slice(0, 12);
+  const cipher = buf.slice(12);
+  const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, cipher);
+  const decoder = new TextDecoder();
+  return JSON.parse(decoder.decode(plain));
+}
+
+/**
+ * Encrypt a profile and upload the ciphertext to IPFS.
+ * Returns the resulting CID that can be stored on-chain.
+ */
+export async function saveProfile(profile: ProfileBlob, key: CryptoKey): Promise<string> {
+  const encrypted = await encryptProfile(profile, key);
+  return uploadToIpfs(encrypted);
+}


### PR DESCRIPTION
## Summary
- expand ProfileManager to store handles and encrypted profile CIDs
- support EAS attestations for preferences, verification, and safety signals
- add client-side utilities for encrypting profiles and uploading to IPFS

## Testing
- `forge test` *(fails: command not found)*
- `curl -L https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel failed 403)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm install` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fbf8cda4832597d09632e40d92af