### PR TITLE
Add upgrade changelog section to landing page

### DIFF
--- a/web3-app/src/app/globals.css
+++ b/web3-app/src/app/globals.css
@@ -198,6 +198,11 @@ body.reduce-motion *::after {
   padding: 4rem 1.25rem;
 }
 
+.changelog-section {
+  display: grid;
+  gap: 3rem;
+}
+
 @media (min-width: 640px) {
   .section-shell { padding: 5.5rem 2.5rem; }
 }
@@ -365,6 +370,78 @@ body.reduce-motion *::after {
 .feature-card__meta {
   font-size: 0.8rem;
   color: color-mix(in srgb, var(--muted) 80%, white 20%);
+}
+
+.changelog-grid {
+  display: grid;
+  gap: 1.75rem;
+}
+
+@media (min-width: 768px) {
+  .changelog-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+}
+
+.changelog-card {
+  position: relative;
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.75rem;
+  border-radius: 1.35rem;
+  background:
+    radial-gradient(circle at top left, rgba(110, 86, 207, 0.22), transparent 55%),
+    color-mix(in srgb, var(--surface) 74%, rgba(18, 14, 31, 0.65));
+  border: 1px solid rgba(231, 227, 255, 0.1);
+  box-shadow: 0 18px 38px rgba(9, 6, 22, 0.35);
+}
+
+.changelog-card::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 1.4rem;
+  border: 1px solid rgba(231, 227, 255, 0.16);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.changelog-card:hover::after {
+  opacity: 1;
+}
+
+.changelog-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.changelog-card__version {
+  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 70%, white 30%);
+}
+
+.changelog-card__codename {
+  margin-top: 0.4rem;
+  font-size: 1.25rem;
+  font-family: var(--font-serif);
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.changelog-card__date {
+  font-size: 0.82rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 78%, white 22%);
+}
+
+.changelog-card__list {
+  gap: 0.65rem;
 }
 
 .list-check,

--- a/web3-app/src/app/page.tsx
+++ b/web3-app/src/app/page.tsx
@@ -124,6 +124,45 @@ const upgradeStats = [
   },
 ];
 
+const upgradeChangelog = [
+  {
+    version: "2025.02",
+    codename: "Aurora mainline",
+    date: "Feb 2025",
+    status: "Live",
+    statusVariant: "ok",
+    highlights: [
+      "Protocol upgrade shipped with rendezvous receipts gating positive reputation.",
+      "Smart account onboarding upgraded with passkey-first Privy + ZeroDev flows.",
+      "Matching engine migrated to deterministic, on-chain governed weights.",
+    ],
+  },
+  {
+    version: "2024.12",
+    codename: "Sentry preview",
+    date: "Dec 2024",
+    status: "In review",
+    statusVariant: "info",
+    highlights: [
+      "Moderator console released for curated guardians with encrypted evidence review.",
+      "Introduced appeals queue with cooldown timers to prevent retaliatory reports.",
+      "Safety attestations now portable across ecosystem clients via shared schemas.",
+    ],
+  },
+  {
+    version: "2024.09",
+    codename: "Beacon cutover",
+    date: "Sep 2024",
+    status: "Research",
+    statusVariant: "warn",
+    highlights: [
+      "Experimenting with refundable intent stakes to discourage spam matchmaking.",
+      "Collecting analytics for match feedback loops and weighted scoring curves.",
+      "Designing privacy-preserving liveness attestations for optional verification.",
+    ],
+  },
+];
+
 type HomeSearchParams = { profile?: string };
 
 export default async function Home({
@@ -231,6 +270,36 @@ export default async function Home({
               <h3 className="heading-serif text-xl font-medium">{feature.title}</h3>
               <p className="text-sm text-soft leading-relaxed">{feature.description}</p>
               <p className="feature-card__meta">{feature.detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section id="changelog" className="section-shell changelog-section">
+        <header className="max-w-3xl space-y-4">
+          <h2 className="heading-serif text-3xl font-semibold">Upgrade changelog</h2>
+          <p className="text-muted text-base sm:text-lg">
+            Track how the protocol hardened over time—from early research cuts to today&apos;s live Aurora mainline release.
+          </p>
+        </header>
+        <div className="changelog-grid mt-10">
+          {upgradeChangelog.map((entry) => (
+            <article key={entry.version} className="changelog-card">
+              <header className="changelog-card__header">
+                <div>
+                  <p className="changelog-card__version">{entry.version}</p>
+                  <p className="changelog-card__codename">{entry.codename}</p>
+                </div>
+                <span className={`status-pill status-pill--${entry.statusVariant}`}>
+                  {entry.status}
+                </span>
+              </header>
+              <p className="changelog-card__date">{entry.date}</p>
+              <ul className="list-check changelog-card__list">
+                {entry.highlights.map((highlight) => (
+                  <li key={highlight}>{highlight}</li>
+                ))}
+              </ul>
             </article>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- add an upgrade changelog section to the landing page so visitors can track each release
- populate the changelog with curated highlights for recent protocol milestones
- style the new changelog grid and cards to match the existing upgrade look and feel

## Testing
- npm run lint *(warnings only from existing directives and img usage)*

------
https://chatgpt.com/codex/tasks/task_e_68e8dc5d3b4c83259d406d268d694687