### PR TITLE
feat: refresh landing experience

### DIFF
--- a/web3-app/src/app/globals.css
+++ b/web3-app/src/app/globals.css
@@ -571,3 +571,313 @@ body.reduce-motion *::after {
 .copy-button:hover {
   border-color: rgba(231, 227, 255, 0.32);
 }
+
+/* Site header */
+.site-header {
+  position: sticky;
+  top: 1rem;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  max-width: 80rem;
+  margin: 0 auto;
+  padding: 1.1rem 1.5rem;
+  border-radius: 1.25rem;
+  background: rgba(10, 10, 15, 0.72);
+  border: 1px solid rgba(231, 227, 255, 0.1);
+  box-shadow: 0 24px 60px rgba(5, 5, 12, 0.4);
+  backdrop-filter: blur(18px);
+}
+
+.logo-lockup {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--foreground);
+}
+
+.logo-glow {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: var(--accent-gold);
+  box-shadow: 0 0 18px rgba(212, 175, 55, 0.8);
+}
+
+.logo-word {
+  font-weight: 600;
+  letter-spacing: 0.14em;
+}
+
+.logo-tag {
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  background: rgba(110, 86, 207, 0.2);
+  border: 1px solid rgba(110, 86, 207, 0.35);
+  color: color-mix(in srgb, var(--foreground) 88%, white 12%);
+}
+
+.nav-links {
+  display: none;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.9rem;
+}
+
+.nav-link {
+  position: relative;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  color: color-mix(in srgb, var(--foreground) 82%, white 18%);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  background: rgba(231, 227, 255, 0.08);
+  color: var(--foreground);
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.nav-status {
+  letter-spacing: 0.14em;
+}
+
+.nav-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1.15rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #05050a;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent-gold) 70%, white 30%), var(--accent-gold));
+  box-shadow: 0 16px 32px -16px rgba(212, 175, 55, 0.45);
+}
+
+.nav-cta:hover {
+  filter: brightness(1.05);
+}
+
+@media (max-width: 1023px) {
+  .site-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+  }
+
+  .nav-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 768px) {
+  .nav-links {
+    display: flex;
+  }
+}
+
+/* Hero highlights */
+.hero-highlight-grid {
+  display: grid;
+  gap: 0.85rem;
+}
+
+@media (min-width: 640px) {
+  .hero-highlight-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.hero-highlight-card {
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(231, 227, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  backdrop-filter: blur(12px);
+}
+
+/* Signals section */
+.section-shell--compact {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+@media (min-width: 640px) {
+  .section-shell--compact {
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+  }
+}
+
+.section-intro {
+  max-width: 40rem;
+  margin: 0 auto 2.5rem;
+  text-align: center;
+}
+
+.signal-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .signal-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.signal-card {
+  position: relative;
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(231, 227, 255, 0.1);
+  background: color-mix(in srgb, var(--surface) 75%, rgba(255, 255, 255, 0.04));
+  box-shadow: 0 22px 40px rgba(7, 6, 18, 0.35);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.signal-card::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: 1.3rem;
+  border: 1px solid rgba(231, 227, 255, 0.12);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.signal-card:hover::after {
+  opacity: 1;
+}
+
+.signal-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 78%, white 22%);
+}
+
+.signal-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: var(--accent-purple);
+  box-shadow: 0 0 10px rgba(110, 86, 207, 0.8);
+}
+
+.signal-metric {
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.signal-delta {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--foreground) 82%, white 18%);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.signal-card--ok .signal-dot {
+  background: rgba(73, 216, 169, 0.95);
+  box-shadow: 0 0 14px rgba(73, 216, 169, 0.7);
+}
+
+.signal-card--ok .signal-delta {
+  color: color-mix(in srgb, #bfffe6 85%, var(--foreground) 15%);
+}
+
+.signal-card--info .signal-dot {
+  background: rgba(110, 86, 207, 0.9);
+}
+
+.signal-card--warn .signal-dot {
+  background: rgba(255, 59, 59, 0.9);
+  box-shadow: 0 0 14px rgba(255, 59, 59, 0.6);
+}
+
+.signal-card--warn .signal-delta {
+  color: color-mix(in srgb, #ffb3b3 84%, var(--foreground) 16%);
+}
+
+/* FAQ */
+.faq-section {
+  padding-bottom: 6rem;
+}
+
+.faq-grid {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2.5rem;
+}
+
+@media (min-width: 768px) {
+  .faq-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.5rem;
+  }
+}
+
+.faq-item {
+  border-radius: 1.1rem;
+  border: 1px solid rgba(231, 227, 255, 0.12);
+  background: color-mix(in srgb, var(--surface) 82%, rgba(110, 86, 207, 0.08));
+  padding: 1.3rem 1.5rem;
+  box-shadow: 0 18px 30px rgba(7, 6, 18, 0.28);
+}
+
+.faq-item summary {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--foreground);
+  list-style: none;
+}
+
+.faq-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq-item summary::after {
+  content: "+";
+  font-size: 1.1rem;
+  font-weight: 400;
+  color: var(--muted);
+  transition: transform 0.25s ease;
+}
+
+.faq-item[open] summary::after {
+  transform: rotate(45deg);
+  color: var(--accent-gold);
+}
+
+.faq-item p {
+  margin-top: 1rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--foreground) 88%, white 12%);
+}

--- a/web3-app/src/app/page.tsx
+++ b/web3-app/src/app/page.tsx
@@ -2,10 +2,33 @@ import Link from "next/link";
 import ConstellationCanvas from "@/components/ConstellationCanvas";
 import ConnectPanel from "@/components/ConnectPanel";
 
+const navLinks = [
+  { href: "#learn-more", label: "Highlights" },
+  { href: "#signals", label: "Signals" },
+  { href: "#changelog", label: "Changelog" },
+  { href: "#get-started", label: "Get started" },
+  { href: "#faq", label: "FAQ" },
+];
+
 const heroBullets = [
   "Transparent, attestable reputation with Rendezvous receipts gating positive signal.",
   "Passkey-first onboarding that quietly deploys a smart account and sponsors gas.",
   "Composable matchmaking rails that any community client can remix.",
+];
+
+const heroHighlights = [
+  {
+    title: "Composable rails",
+    description: "SDK primitives for intents, scoring, and rendezvous flows that every client can extend.",
+  },
+  {
+    title: "Safety-forward",
+    description: "Receipts, moderation attestations, and encrypted evidence pipelines by default.",
+  },
+  {
+    title: "Gasless onboarding",
+    description: "Passkey-first accounts with sponsored actions so newcomers never touch a seed phrase.",
+  },
 ];
 
 const featureHighlights = [
@@ -90,6 +113,33 @@ const guardrails = [
   "Opt-in privacy layers so sensitive evidence never hits the public chain.",
 ];
 
+const ecosystemSignals = [
+  {
+    label: "Active rendezvous",
+    value: "8,120",
+    change: "+32% month over month",
+    tone: "ok",
+  },
+  {
+    label: "Verified guardians",
+    value: "142",
+    change: "+18 onboarded this quarter",
+    tone: "info",
+  },
+  {
+    label: "Attestations issued",
+    value: "54,300",
+    change: "+4.7k past 7 days",
+    tone: "ok",
+  },
+  {
+    label: "Escalations resolved",
+    value: "98%",
+    change: "Under 36h median response",
+    tone: "warn",
+  },
+];
+
 const roadmap = [
   {
     label: "Shipping now",
@@ -163,6 +213,29 @@ const upgradeChangelog = [
   },
 ];
 
+const faqEntries = [
+  {
+    question: "How do sponsored actions stay sustainable?",
+    answer:
+      "We route onboarding transactions through rotating paymasters funded by DAO-set budgets. Guardians vote on the budget each epoch while analytics flag abusive usage for throttling.",
+  },
+  {
+    question: "Can communities run their own scoring curves?",
+    answer:
+      "Yes. The deterministic weights ship as governance-controlled parameters. Any community client can fork the template contract, adjust multipliers, and publish their configuration as an attestation.",
+  },
+  {
+    question: "What happens if a guardian issues a false report?",
+    answer:
+      "Appeals queue cases require multi-guardian quorum. Every moderation action emits an attestation that can be challenged, with cooldown periods that prevent instant retaliatory adjustments.",
+  },
+  {
+    question: "Where are encrypted profiles stored?",
+    answer:
+      "Profile blobs live on IPFS using access-controlled encryption. The smart account only references the CID, while Privy controls who can decrypt based on user consent and guardian policies.",
+  },
+];
+
 type HomeSearchParams = { profile?: string };
 
 export default async function Home({
@@ -178,7 +251,35 @@ export default async function Home({
   const profileCreated = resolvedSearchParams?.profile === "complete";
 
   return (
-    <main className="relative min-h-screen overflow-hidden vignette noise-soft aurora-bg">
+    <main
+      id="top"
+      className="relative min-h-screen overflow-hidden vignette noise-soft aurora-bg"
+    >
+      <header className="site-header" aria-label="Primary">
+        <Link href="#top" className="logo-lockup" aria-label="Kindling protocol home">
+          <span className="logo-glow" aria-hidden />
+          <span className="logo-word">Kindling</span>
+          <span className="logo-tag">Protocol</span>
+        </Link>
+        <nav className="nav-links" aria-label="Jump to section">
+          {navLinks.map((item) => (
+            <Link key={item.href} href={item.href} className="nav-link">
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="nav-actions">
+          <span className="status-pill status-pill--info nav-status">Beta cohort live</span>
+          <a
+            href="mailto:hello@kindling.xyz"
+            className="nav-cta"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Request invite
+          </a>
+        </div>
+      </header>
       <section className="relative mx-auto max-w-6xl px-4 py-16 sm:px-6 sm:py-28">
         <div className="absolute inset-0 -z-10">
           <ConstellationCanvas density={0.00075} />
@@ -218,6 +319,14 @@ export default async function Home({
                 <li key={bullet}>{bullet}</li>
               ))}
             </ul>
+            <div className="hero-highlight-grid">
+              {heroHighlights.map((item) => (
+                <div key={item.title} className="hero-highlight-card">
+                  <h3 className="text-sm uppercase tracking-[0.18em] text-muted">{item.title}</h3>
+                  <p className="text-sm text-soft leading-relaxed">{item.description}</p>
+                </div>
+              ))}
+            </div>
             <div className="microcopy">No seed phrases. No gas. Yours to own.</div>
             {profileCreated && (
               <div className="upgrade-alert" role="status">
@@ -253,6 +362,27 @@ export default async function Home({
               </div>
             </div>
           </aside>
+        </div>
+      </section>
+
+      <section id="signals" className="section-shell section-shell--compact">
+        <div className="section-intro">
+          <h2 className="heading-serif text-3xl font-semibold">Network signals</h2>
+          <p className="text-muted text-base sm:text-lg">
+            Community-owned analytics surface the pulse of the protocol without exposing personal context.
+          </p>
+        </div>
+        <div className="signal-grid">
+          {ecosystemSignals.map((signal) => (
+            <article key={signal.label} className={`signal-card signal-card--${signal.tone}`}>
+              <p className="signal-label">
+                <span className="signal-dot" aria-hidden />
+                {signal.label}
+              </p>
+              <p className="signal-metric heading-serif">{signal.value}</p>
+              <p className="signal-delta">{signal.change}</p>
+            </article>
+          ))}
         </div>
       </section>
 
@@ -353,6 +483,25 @@ export default async function Home({
               </ul>
             </div>
           </aside>
+        </div>
+      </section>
+
+      <section id="faq" className="section-shell faq-section">
+        <header className="max-w-3xl space-y-4">
+          <h2 className="heading-serif text-3xl font-semibold">FAQ &amp; playbook</h2>
+          <p className="text-muted text-base sm:text-lg">
+            Quick answers for operators rolling out the upgrade across their communities.
+          </p>
+        </header>
+        <div className="faq-grid">
+          {faqEntries.map((entry) => (
+            <details key={entry.question} className="faq-item">
+              <summary>
+                <span>{entry.question}</span>
+              </summary>
+              <p>{entry.answer}</p>
+            </details>
+          ))}
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add a sticky navigation header with invite CTA and an expanded hero highlight row
- introduce a network signals metrics section plus an FAQ playbook on the landing page
- extend global styling with responsive glassmorphic treatments for the new sections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ea469afb9083258deb9a9dab4ac989